### PR TITLE
fix: nil cdtext error in SetCooldown

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -71,7 +71,13 @@ function prototype:SetDominantColor(r, g, b)
 	self.Border:SetAlpha(SPECIAL_COLOR_ALPHA)
 
 	-- Color the Blizzard Cooldown Text
-	local cdtext = select(1, self.Cooldown:GetRegions())
+	local cdtext
+	for _, region in ipairs({ self.Cooldown:GetRegions() }) do
+		if region:GetObjectType() == "FontString" then
+			cdtext = region
+			break
+		end
+	end
 	if cdtext and cdtext.SetTextColor then
 		cdtext:SetTextColor(r, g, b)
 	end
@@ -124,9 +130,7 @@ end
 function prototype:SetCooldown(remain, duration, usable)
 	local cdtext = select(1, self.Cooldown:GetRegions())
 	local r, g, b
-	if cdtext:GetObjectType() ~= "FontString" then
-		cdtext = nil
-	else
+	if cdtext then
 		r, g, b = cdtext:GetTextColor()
 	end
 


### PR DESCRIPTION
Fixes this error:
```
5788x OPieMasque/Addon.lua:127: attempt to index local 'cdtext' (a nil value)
[OPieMasque/Addon.lua]:127: in function 'SetCooldown'
[OPie/UI/RingView.lua]:596: in function 'f'
[OPie/UI/RingView.lua]:628: in function <OPie/UI/RingView.lua:627>
[C]: in function 'securecall'
[OPie/UI/RingView.lua]:738: in function <OPie/UI/RingView.lua:673>
[tail call]: ?


Locals:
self = OPieSliceButton6 {
 popupDirection = "UP"
 NewActionTexture = Texture {
 }
 BorderShadow = Texture {
 }
 TargetReticleAnimFrame = Frame {
 }
 icon = OPieSliceButton6Icon {
 }
 SlotArt = Texture {
 }
 icon_r = 1
 closedArrowOffset = 4
 popupOffset = -4
 enableSpellFX = true
 Name = OPieSliceButton6Name {
 }
 arrowCrossAxisSize = 7
 _MSQ_Hook_UpdateButtonArt = true
 OverlayIcon = Texture {
 }
 hotkeyTextGamepadX = 0
 CooldownFlash = Frame {
 }
 IconMask = MaskTexture {
 }
 Icon = OPieSliceButton6Icon {
 }
 arrowMainAxisSize = 18
 CheckedTexture = Texture {
 }
 SpellHighlightAnim = AnimationGroup {
 }
 hotkeyTextKeyboardX = -4
 _MSQ_CFG = <table> {
 }
 PushedTexture = Texture {
 }
 hotkeyTextKeyboardY = -5
 arrowDownTexture = "UI-HUD-ActionBar-Flyout-Down"
 AutoCastOverlay = Frame {
 }
 icon_g = 1
 Border = OPieSliceButton6Border {
 }
 hotkeyTextGamepadY = 0
 openArrowOffset = 2
 arrowNormalTexture = "UI-HUD-ActionBar-Flyout"
 SpellCastAnimFrame = Frame {
 }
 chargeCooldown = Cooldown {
 }
 popupCrossAxisSize = 47
 GlowTextures = <table> {
 }
 ProfessionQualityOverlayFrame = Frame {
 }
 arrowOverTexture = "UI-HUD-ActionBar-Flyout-Mouseover"
 lossOfControlCooldown = Cooldown {
 }
 HighlightTexture = Texture {
 }
 NormalTexture = OPieSliceButton6NormalTexture {
 }
 Cooldown = OPieSliceButton6Cooldown {
 }
 ustate = 3
 Count = OPieSliceButton6Count {
 }
 HotKey = OPieSliceButton6HotKey {
 }
 Arrow = Texture {
 }
 TextOverlayContainer = Frame {
 }
 LevelLinkLockIcon = Texture {
 }
 enableLOCCooldown = true
 icon_b = 1
 Flash = OPieSliceButton6Flash {
 }
 SpellHighlightTexture = Texture {
 }
 InterruptDisplay = Frame {
 }
 SlotBackground = Texture {
 }
 cooldown = OPieSliceButton6Cooldown {
 }
}
remain = 6942.221000
duration = 7200
usable = false
cdtext = nil
r = nil
g = nil
b = nil
(*temporary) = OPieSliceButton6Cooldown {
 tullaCTC = Frame {
 }
 _MSQ_Color = <table> {
 }
}
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index local 'cdtext' (a nil value)"
```
